### PR TITLE
Change MercureBroadcaster to implements Laravel Broadcaster interface

### DIFF
--- a/src/Broadcasting/Broadcasters/MercureBroadcaster.php
+++ b/src/Broadcasting/Broadcasters/MercureBroadcaster.php
@@ -2,11 +2,11 @@
 
 namespace Duijker\LaravelMercureBroadcaster\Broadcasting\Broadcasters;
 
-use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 
-class MercureBroadcaster extends Broadcaster
+class MercureBroadcaster implements Broadcaster
 {
     protected HubInterface $hub;
 


### PR DESCRIPTION
Just noticed that implementing Laravel Broadcaster interface is enough to make a custom broadcaster driver, i thought i would open a PR for this little change, thanks for your work @mvanduijker it helped me a lot to use Mercure.rocks in my project 👍🏼 