### PR TITLE
Allow lcobucci/jwt v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "illuminate/broadcasting": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
-        "lcobucci/jwt": "~4.0",
+        "lcobucci/jwt": "~4.0|~5.0",
         "symfony/mercure": "~0.4"
     },
     "require-dev": {


### PR DESCRIPTION
Hi there! I tried to set up this package in my app, but I had a version conflict for `lcobucci/jwt` at v5.4. 

I expanded the version constraints to include v5. You can review the release notes for v5 [here](https://github.com/lcobucci/jwt/releases/tag/5.0.0).

Since testing it whilst getting my Mercure hub set up, there doesn't appear to be any breaking changes or incompatibilities. It all just worked as expected 👍 So hopefully this can be merged in for anyone else already using the library.

Thanks!