### PR TITLE
fix: handle undefined $private property on Channel objects

### DIFF
--- a/src/Broadcasting/Broadcasters/MercureBroadcaster.php
+++ b/src/Broadcasting/Broadcasters/MercureBroadcaster.php
@@ -2,6 +2,7 @@
 
 namespace Duijker\LaravelMercureBroadcaster\Broadcasting\Broadcasters;
 
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
@@ -56,7 +57,8 @@ class MercureBroadcaster implements Broadcaster
         ]);
 
         foreach ($channels as $channel) {
-            $this->hub->publish(new Update($channel->name, $payload, $channel->private));
+            $isPrivate = $channel instanceof PrivateChannel;
+            $this->hub->publish(new Update($channel->name, $payload, $isPrivate));
         }
     }
 }


### PR DESCRIPTION
### Problem
  When broadcasting events using Laravel's built-in `Channel` or `PrivateChannel` classes, the broadcaster attempts to access `$channel->private` property which doesn't exist on these classes, resulting in:

  ErrorException: Undefined property: Illuminate\Broadcasting\PrivateChannel::$private

  ### Root Cause
  - `Illuminate\Broadcasting\Channel` doesn't have a `$private` property
  - `Illuminate\Broadcasting\PrivateChannel` (which extends `Channel`) also doesn't have this property
  - The broadcaster assumes all channel objects have this property

  ### Solution
  Instead of accessing a non-existent property, determine if the channel is private by checking its type using `instanceof`.
  
  ### Links
  - https://api.laravel.com/docs/12.x/Illuminate/Broadcasting/Channel.html
  - https://api.laravel.com/docs/12.x/Illuminate/Broadcasting/PrivateChannel.html